### PR TITLE
feat: Expand the default chunk loading threshold to 1000

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -2553,6 +2553,10 @@ file = "icon.png"
 hash = "78b5fdc7f5945756104be53854115c89cb38b4714183af86b07c6f7377e8685c"
 
 [[files]]
+file = "local/ftbutilities/ranks.txt"
+hash = "5b6d3b43aaf002a5e8e8b4469c8c65999455e4da21b52ed4d797ef3454ab4834"
+
+[[files]]
 file = "mods/ae2-crafting-tree-legacy.pw.toml"
 hash = "64e7a392556a055d0e9566b47937a51febf61251694b8e72a145d5f7e55d6d7a"
 metafile = true

--- a/local/ftbutilities/ranks.txt
+++ b/local/ftbutilities/ranks.txt
@@ -1,0 +1,21 @@
+// For more info visit https://faq.ftb.world/books/ftb-utilities/page/ranks
+
+[player]
+default_player_rank: true
+power: 1
+example.permission: true
+example.other_permission: false
+example.permission_with_value: 0
+
+[vip]
+power: 20
+ftbutilities.chat.name_format: <&bVIP {name}&r>
+example.other_permission: true
+example.permission_with_value: 15
+
+[admin]
+default_op_rank: true
+power: 100
+ftbutilities.chat.name_format: <&2{name}&r>
+example.permission_with_value: 100
+ftbutilities.chunkloader.max_chunks: 1000

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,11 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
+<<<<<<< Updated upstream
 hash = "024b31dd393026a12862a3c81657095b0c705dee065fe4aebc5f43cd244f5579"
+=======
+hash = "2eea8d655a59d7bc860652763c01907b00fefeb10f37c134e6cb25c254950e5e"
+>>>>>>> Stashed changes
 
 [versions]
 forge = "14.23.5.2860"

--- a/pack.toml
+++ b/pack.toml
@@ -6,11 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-<<<<<<< Updated upstream
-hash = "024b31dd393026a12862a3c81657095b0c705dee065fe4aebc5f43cd244f5579"
-=======
-hash = "2eea8d655a59d7bc860652763c01907b00fefeb10f37c134e6cb25c254950e5e"
->>>>>>> Stashed changes
+hash = "be01a117d2ee4acec42ec752f45c49ed7fac4020da71ec5f6d19c27b6d857d37"
 
 [versions]
 forge = "14.23.5.2860"


### PR DESCRIPTION
Add chunk loading config file and set the default chunk loading threshold to 1000 to replace the default limit of 100 chunks